### PR TITLE
support test suite helpers

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -48,7 +48,7 @@ module Kitchen
                            raise Kitchen::UserError, "Verifier #{name}",
                              " does not support the #{name} Transport"
                          end
-        tests = local_suite_files
+        tests = helper_files + local_suite_files
 
         runner = ::Inspec::Runner.new(runner_options)
         runner.add_tests(tests)
@@ -72,6 +72,16 @@ module Kitchen
       # (see Base#load_needed_dependencies!)
       def load_needed_dependencies!
         require "inspec"
+      end
+
+      # Returns an Array of common helper filenames currently residing on the
+      # local workstation.
+      #
+      # @return [Array<String>] array of helper files
+      # @api private
+      def helper_files
+        glob = File.join(config[:test_base_path], "helpers", "*/**/*")
+        Dir.glob(glob).reject { |f| File.directory?(f) }
       end
 
       # Returns an Array of test suite filenames for the related suite currently

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -61,7 +61,20 @@ describe Kitchen::Verifier::Inspec do
   end
 
   let(:test_files) do
-    %w[base_spec.rb another_spec.rb supporting.rb other.json]
+    %w(
+      inspec/base_spec.rb
+      inspec/another_spec.rb
+      inspec/supporting.rb
+      inspec/other.json
+    )
+  end
+
+  let(:helper_files) do
+    %w(
+      inspec/spec_helper.rb
+      inspec/support/custom.rb
+      inspec/support/more_custom.rb
+    )
   end
 
   before do
@@ -153,10 +166,13 @@ describe Kitchen::Verifier::Inspec do
     it "adds *spec.rb test files to runner" do
       create_test_files
       allow(Inspec::Runner).to receive(:new).and_return(runner)
-      expect(runner).to receive(:add_tests).with([
-        File.join(config[:test_base_path], "germany", "another_spec.rb"),
-        File.join(config[:test_base_path], "germany", "base_spec.rb")
-      ])
+      expect(runner).to receive(:add_tests).with(array_including([
+        File.join(config[:test_base_path], "germany", "inspec", "another_spec.rb"),
+        File.join(config[:test_base_path], "germany", "inspec", "base_spec.rb"),
+        File.join(config[:test_base_path], "helpers", "inspec", "spec_helper.rb"),
+        File.join(config[:test_base_path], "helpers", "inspec", "support", "custom.rb"),
+        File.join(config[:test_base_path], "helpers", "inspec", "support", "more_custom.rb")
+      ]))
 
       verifier.call(Hash.new)
     end
@@ -220,12 +236,21 @@ describe Kitchen::Verifier::Inspec do
     end
   end
 
+  def create_file(file, content)
+    FileUtils.mkdir_p(File.dirname(file))
+    File.open(file, "wb") { |f| f.write(content) }
+  end
+
   def create_test_files
     base = File.join(config[:test_base_path], "germany")
+    hbase = File.join(config[:test_base_path], "helpers")
 
     test_files.map { |f| File.join(base, f) }.each do |file|
-      FileUtils.mkdir_p(File.dirname(file))
-      File.open(file, "wb") { |f| f.write("hello") }
+      create_file(file, 'hello')
+    end
+
+    helper_files.map { |f| File.join(hbase, f) }.each do |file|
+      create_file(file, 'hello')
     end
   end
 end


### PR DESCRIPTION
Test Kitchen's default verifier, Busser, has support for loading helper files which include things like:

* spec_helper
* InSpec custom resources
* RSpec shared examples
* RSpec shared contexts
* RSpec custom matchers

These helper files are meant to be shared amongst all test suites in a project structure like:

```
test/integration/
├── helpers
│   └── <VERIFIER>
│       ├── spec_helper.rb
│       └── support
│           └── some_file.rb
├── suite1
│   └── <VERIFIER>
│       └── some_spec.rb
└── suite2
    └── <VERIFIER>
         └── some_spec.rb
```

Some real world examples can be seen at:
https://github.com/chef-cookbooks/jenkins/tree/master/test/integration
https://github.com/chef-cookbooks/languages/tree/master/test/integration
https://github.com/chef-cookbooks/omnibus/tree/master/test/integration

This change ensures `Kitchen::Verifier::Inspec` fully supports these helper files!

/cc @chef/compliance @chef/engineering-services 