### PR TITLE
Make test-kitchen a dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ end
 group :tools do
   gem 'github_changelog_generator', '~> 1'
 end
+
+group :development do
+  gem 'test-kitchen', '~> 1.4', :require => nil
+end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'test-kitchen', '~> 1.4'
   spec.add_dependency 'inspec', '~> 0.9'
   spec.add_development_dependency 'countloc', '~> 0.4'
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
The dependency on test-kitchen is breaking chefdk. I think this will fix it.
cc @tyler-ball @chris-rock @fnichol 