### PR TITLE
Add integration test with test-kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+test/integration/.kitchen
+Berksfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
+---
+sudo: required
 language: ruby
+cache: bundler
+
+# necessary for docker to work
+dist: trusty
+services:
+  - docker
 
 rvm:
   - 2.2
@@ -7,11 +15,23 @@ rvm:
   - 1.9.3
   - ruby-head
 
-before_install: gem install bundler -v 1.10.6
-bundler_args: --without guard
+bundler_args: --without guard integration
 
-sudo: false
+before_install:
+  - gem update --system 2.4.5
+  - gem --version
 
 matrix:
+  include:
+    - rvm: 1.9.3
+      gemfile: Gemfile
+    - rvm: 2.0
+      gemfile: Gemfile
+    - rvm: 2.1
+      gemfile: Gemfile
+    - rvm: 2.2
+      gemfile: Gemfile
+    - rvm: ruby-head
+      gemfile: Gemfile
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,7 @@ dist: trusty
 services:
   - docker
 
-rvm:
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - 1.9.3
-  - ruby-head
-
-bundler_args: --without guard integration
+bundler_args: --without integration guard tools
 
 before_install:
   - gem update --system 2.4.5
@@ -33,5 +26,9 @@ matrix:
       gemfile: Gemfile
     - rvm: ruby-head
       gemfile: Gemfile
+    - rvm: 2.2
+      gemfile: Gemfile
+      bundler_args: --without guard tools
+      script: bundle exec rake test:integration
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.1
       gemfile: Gemfile
-    - rvm: 2.2
-      gemfile: Gemfile
     - rvm: ruby-head
       gemfile: Gemfile
     - rvm: 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ group :tools do
   gem 'github_changelog_generator', '~> 1'
 end
 
-group :development do
+group :integration do
+  gem 'berkshelf', '~> 4.0'
   gem 'test-kitchen', '~> 1.4', :require => nil
+  gem 'kitchen-dokken'
+  gem 'kitchen-inspec', path: '.'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,21 @@ group :guard do
 end
 
 group :test do
+  gem 'bundler', '~> 1.5'
+  gem 'minitest', '~> 5.5'
+  gem 'rake', '~> 10'
+  gem 'rubocop', '~> 0.32'
+  gem 'concurrent-ruby', '~> 0.9'
   gem 'codeclimate-test-reporter', :require => nil
-end
-
-group :tools do
-  gem 'github_changelog_generator', '~> 1'
+  gem 'test-kitchen', '~> 1.4', :require => nil
 end
 
 group :integration do
-  gem 'berkshelf', '~> 4.0'
-  gem 'test-kitchen', '~> 1.4', :require => nil
+  gem 'berkshelf'
   gem 'kitchen-dokken'
-  gem 'kitchen-inspec', path: '.'
+end
+
+group :tools do
+  gem 'pry', '~> 0.10'
+  gem 'github_changelog_generator', '~> 1'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -118,3 +118,11 @@ task :bump_version, [:version] do |_, args|
   kitchen_inspec_version(v)
   Rake::Task['changelog'].invoke
 end
+
+namespace :test do
+  task :integration do
+    concurrency = ENV['CONCURRENCY'] || 1
+    path = File.join(File.dirname(__FILE__), 'test', 'integration')
+    sh('sh', '-c', "cd #{path} && bundle exec kitchen test -c #{concurrency} -t .")
+  end
+end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -96,7 +96,8 @@ module Kitchen
           runner_options_for_ssh(transport_data)
         elsif transport.is_a?(Kitchen::Transport::Winrm)
           runner_options_for_winrm(transport_data)
-        elsif transport.is_a?(Kitchen::Transport::Dokken)
+        # optional transport which is not in core test-kitchen
+        elsif defined?(Kitchen::Transport::Dokken) && transport.is_a?(Kitchen::Transport::Dokken)
           runner_options_for_docker(transport_data)
         else
           fail Kitchen::UserError, "Verifier #{name} does not support the #{transport.name} Transport"

--- a/test/integration/.kitchen.yml
+++ b/test/integration/.kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: dokken
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+verifier:
+  name: inspec
+  sudo: true
+
+platforms:
+- name: ubuntu
+  driver:
+      image: ubuntu:14.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[os_prepare]
+    attributes:

--- a/test/integration/Berksfile
+++ b/test/integration/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+cookbook 'os_prepare', path: './cookbooks/os_prepare'

--- a/test/integration/cookbooks/os_prepare/metadata.rb
+++ b/test/integration/cookbooks/os_prepare/metadata.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+name 'os_prepare'
+maintainer 'Chef Software, Inc.'
+maintainer_email 'support@chef.io'
+description 'This cookbook prepares the test operating systems'
+version '1.0.0'
+depends 'apt'
+depends 'yum'

--- a/test/integration/cookbooks/os_prepare/recipes/default.rb
+++ b/test/integration/cookbooks/os_prepare/recipes/default.rb
@@ -1,0 +1,5 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+#
+# noop, do nothing

--- a/test/integration/test/integration/default/_debug_spec.rb
+++ b/test/integration/test/integration/default/_debug_spec.rb
@@ -1,0 +1,1 @@
+p "You are currently running on OS family: #{os[:family] || 'unknown'}, OS release: #{os[:release] || 'unknown'}"

--- a/test/integration/test/integration/default/os_spec.rb
+++ b/test/integration/test/integration/default/os_spec.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+family = os[:family]
+
+describe os[:family] do
+  it { should eq family }
+end


### PR DESCRIPTION
This PR introduces a real-world run of `kitchen-inspec` in combination with `test-kitchen`.