### PR TITLE
Add support for remote profiles

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,12 +21,11 @@ suites:
   - name: default
     run_list:
       - recipe[os_prepare]
-    attributes:
   - name: profile
     run_list:
       - recipe[os_prepare]
-    attributes:
   - name: contains_inspec
     run_list:
       - recipe[os_prepare]
-    attributes:
+    inspec_tests:
+      - https://github.com/nathenharvey/tmp_compliance_profile

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -66,9 +66,7 @@ module Kitchen
 
       # (see Base#call)
       def call(state)
-        p config[:inspec_tests]
-        # get local tests and get run list of profiles
-        tests = (local_suite_files + config[:inspec_tests]).compact
+        tests = collect_tests
 
         opts = runner_options(instance.transport, state)
         runner = ::Inspec::Runner.new(opts)
@@ -95,7 +93,7 @@ module Kitchen
       # - test/integration
       # - test/integration/inspec (prefered if used with other test environments)
       #
-      # @return [Array<String>] array of suite files
+      # @return [Array<String>] array of suite directories
       # @api private
       def local_suite_files
         base = File.join(config[:test_base_path], config[:suite_name])
@@ -113,6 +111,14 @@ module Kitchen
 
         # we do not filter for specific directories, this is core of inspec
         [base]
+      end
+
+      # Returns an array of test profiles
+      # @return [Array<String>] array of suite directories or remote urls
+      # @api private
+      def collect_tests
+        # get local tests and get run list of profiles
+        (local_suite_files + config[:inspec_tests]).compact
       end
 
       # Returns a configuration Hash that can be passed to a `Inspec::Runner`.

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -162,7 +162,7 @@ describe Kitchen::Verifier::Inspec do
       verifier.call(port: 123)
     end
 
-    it 'find test path for runner' do
+    it 'find test directory for runner' do
       # create_test_files
       allow(Inspec::Runner).to receive(:new).and_return(runner)
       expect(runner).to receive(:add_target).with(
@@ -174,7 +174,7 @@ describe Kitchen::Verifier::Inspec do
       verifier.call({})
     end
 
-    it 'find test path for runner if legacy' do
+    it 'find test directory for runner if legacy' do
       create_legacy_test_directories
       allow(Inspec::Runner).to receive(:new).and_return(runner)
       expect(runner).to receive(:add_target).with(
@@ -190,6 +190,53 @@ describe Kitchen::Verifier::Inspec do
       allow(Inspec::Runner).to receive(:new).and_return(runner)
       expect(runner).to receive(:run)
 
+      verifier.call({})
+    end
+  end
+
+  context 'with an remote profile' do
+
+    let(:transport) do
+      Kitchen::Transport::Ssh.new({})
+    end
+
+    let(:runner) do
+      instance_double('Inspec::Runner')
+    end
+
+    let(:suite) do
+      instance_double('Kitchen::Suite', { name: 'local' })
+    end
+
+    let(:instance) do
+      instance_double(
+        'Kitchen::Instance',
+        name: 'coolbeans',
+        logger: logger,
+        platform: platform,
+        suite: suite,
+        transport: transport,
+        to_str: 'instance',
+      )
+    end
+
+    let(:config) {
+      {
+        inspec_tests: ['https://github.com/nathenharvey/tmp_compliance_profile'],
+      }
+    }
+
+    before do
+      allow(runner).to receive(:add_target)
+      allow(runner).to receive(:run).and_return 0
+    end
+
+    it 'find test directory and remote profile' do
+      allow(Inspec::Runner).to receive(:new).and_return(runner)
+      expect(runner).to receive(:add_target).with(
+        File.join(config[:test_base_path], 'local'), anything)
+      expect(runner).to receive(:add_target).with(
+        'https://github.com/nathenharvey/tmp_compliance_profile', anything)
       verifier.call({})
     end
   end


### PR DESCRIPTION
This adds supports for remote profiles in Kitchen-InSpec. Just add the `inspec_tests` section to `.kitchen.yml` and those profiles will be executed in addition to the tests located in `test/integration`

```
suites:
  - name: profile
    run_list:
      - recipe[os_prepare]
    inspec_tests:
      - https://github.com/nathenharvey/tmp_compliance_profile
```
