### PR TITLE
Use only the keys provided by Kitchen

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -139,6 +139,7 @@ module Kitchen
           'max_wait_until_ready' => kitchen[:max_wait_until_ready],
           'compression' => kitchen[:compression],
           'compression_level' => kitchen[:compression_level],
+          'keys_only' => true,
         }
         opts['key_files'] = kitchen[:keys] unless kitchen[:keys].nil?
         opts['password'] = kitchen[:password] unless kitchen[:password].nil?


### PR DESCRIPTION
Hi,

I'm using Kitchen for Ansible with Docker.
I have a ssh configuration and multiple keys. Without the key_only set to true, NetSSH is trying all my keys before using the Kitchen key.
I think it makes sense to limit the keys used to the one kitchen is using.

