### PR TITLE
Supermarket and Compliance support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,3 +30,20 @@ suites:
     verifier:
       inspec_tests:
         - https://github.com/nathenharvey/tmp_compliance_profile
+  - name: supermarket
+    run_list:
+      - recipe[apt]
+      - recipe[ssh-hardening]
+    verifier:
+      inspec_tests:
+        - supermarket://hardening/ssh-hardening
+  # before you are able to use the compliance plugin, you need to run
+  # insecure is only required if you use self-signed certificates
+  # $ inspec compliance login https://compliance.test --user admin --insecure --token ''
+  - name: compliance
+    run_list:
+      - recipe[apt]
+      - recipe[ssh-hardening]
+    verifier:
+      inspec_tests:
+        - compliance://base/ssh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ matrix:
   - rvm: ruby-head
   - rvm: 2.2
     bundler_args: "--without guard tools"
-    script: bundle exec rake test:integration
+    script: bundle exec rake test:integration OS='default profile contains_inspec'
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake test:integration OS='supermarket'
   allow_failures:
   - rvm: ruby-head
 deploy:

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,7 @@
 
 source 'https://supermarket.chef.io'
 
+cookbook 'apt'
+cookbook 'yum'
 cookbook 'os_prepare', path: './test/cookbooks/os_prepare'
+cookbook 'ssh-hardening', git: 'https://github.com/dev-sec/chef-ssh-hardening.git'

--- a/Rakefile
+++ b/Rakefile
@@ -122,7 +122,7 @@ end
 namespace :test do
   task :integration do
     concurrency = ENV['CONCURRENCY'] || 1
-    path = File.join(File.dirname(__FILE__), 'test', 'integration')
-    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency}")
+    os = ENV['OS'] || ''
+    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency} #{os}")
   end
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_dependency 'inspec', '>=0.14.1', '<1.0.0'
+  spec.add_dependency 'inspec', '>=0.20.0', '<1.0.0'
   spec.add_dependency 'test-kitchen', '~> 1.6'
   spec.add_development_dependency 'countloc', '~> 0.4'
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -54,6 +54,17 @@ module Kitchen
       # (see Base#load_needed_dependencies!)
       def load_needed_dependencies!
         require 'inspec'
+        # TODO: this should be easier. I would expect to load a single class here
+        # load supermarket plugin, this is part of the inspec gem
+        require 'bundles/inspec-supermarket/api'
+        require 'bundles/inspec-supermarket/target'
+
+        # load the compliance plugin
+        require 'bundles/inspec-compliance/configuration'
+        require 'bundles/inspec-compliance/support'
+        require 'bundles/inspec-compliance/http'
+        require 'bundles/inspec-compliance/api'
+        require 'bundles/inspec-compliance/target'
       end
 
       # Returns an Array of test suite filenames for the related suite currently


### PR DESCRIPTION
allows kitchen-inspec to work with inspec supermarket profiles and profiles stored in Chef Compliance

fixes #80
superseeds https://github.com/chef/inspec/pull/703

You can define the profiles as following:

```
suites:
  - name: supermarket
    run_list:
      - recipe[ssh-hardening]
    verifier:
      inspec_tests:
        - supermarket://hardening/ssh-hardening
  # before you are able to use the compliance plugin, you need to run
  # insecure is only required if you use self-signed certificates
  # $ inspec compliance login https://compliance.test --user admin --insecure --token ''
  - name: compliance
    run_list:
      - recipe[ssh-hardening]
    verifier:
      inspec_tests:
        - compliance://base/ssh
```