### PR TITLE
support for sudo_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optionally specify sudo and sudo_command
 verifier:
   name: inspec
   sudo: true
-  sudo_command: 'supersizeme'
+  sudo_command: 'skittles'
 ```
 
 ### Directory Structure

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ verifier:
   name: inspec
 ```
 
+Optionally, specify sudo and sudo_command if needed
+```
+verifier:
+  name: inspec
+  sudo: true
+  sudo_command: 'supersizeme'
+```
+
 ### Directory Structure
 
 By default `kitchen-inspec` expects test to be in `test/integration/%suite%` directory structure (we use Chef as provisioner here):

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ verifier:
   name: inspec
 ```
 
-Optionally, specify sudo and sudo_command if needed
+Optionally specify sudo and sudo_command
 ```
 verifier:
   name: inspec

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -143,6 +143,7 @@ module Kitchen
           'logger' => logger,
           # pass-in sudo config from kitchen verifier
           'sudo' => config[:sudo],
+          'sudo_command' => config[:sudo_command],
           'host' => kitchen[:hostname],
           'port' => kitchen[:port],
           'user' => kitchen[:username],

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -122,6 +122,7 @@ describe Kitchen::Verifier::Inspec do
 
     it 'constructs a Inspec::Runner using transport config data and state' do
       config[:sudo] = 'jellybeans'
+      config[:sudo_command] = 'allyourbase'
 
       expect(Inspec::Runner).to receive(:new)
         .with(
@@ -129,6 +130,7 @@ describe Kitchen::Verifier::Inspec do
             'backend' => 'ssh',
             'logger' => logger,
             'sudo' => 'jellybeans',
+            'sudo_command' => 'allyourbase',
             'host' => 'boogie',
             'port' => 123,
             'user' => 'dance',


### PR DESCRIPTION
This implements `sudo_command` option for the verifier.

Related to this in train: https://github.com/chef/train/pull/107
