### PR TITLE
Require Ruby 2.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ before_install:
   - gem --version
 matrix:
   include:
-  - rvm: 2.0
   - rvm: 2.1.9
-  - rvm: ruby-head
   - rvm: 2.2.5
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake test:integration OS='default profile contains_inspec'
-  - rvm: 2.2.5
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake test:integration OS='supermarket'
+  - rvm: ruby-head
   allow_failures:
   - rvm: ruby-head
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -8,26 +8,23 @@ group :guard do
 end
 
 group :test do
-  gem "bundler", "~> 1.5"
+  gem "bundler", "~> 1.10"
   gem "minitest", "~> 5.5"
-  gem "rake", "~> 10"
-  gem "chefstyle", "~> 0.4.0"
+  gem "rake", "~> 11.0"
+  gem "chefstyle", "0.4.0"
   gem "concurrent-ruby", "~> 0.9"
   gem "codeclimate-test-reporter", :require => nil
-end
-
-# pin dependency for Ruby 1.9.3 since bundler is not
-# detecting that net-ssh 3 does not work with 1.9.3
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("1.9.3")
-  gem "net-ssh", "~> 2.9"
+  gem "rspec"
+  gem "simplecov", "~> 0.12"
+  gem "countloc", "~> 0.4"
 end
 
 group :integration do
-  gem "berkshelf", ">= 4.2.3"
+  gem "berkshelf", ">= 4.3.5"
   gem "kitchen-dokken"
 end
 
 group :tools do
   gem "pry", "~> 0.10"
-  gem "github_changelog_generator", "1.11.3"
+  gem "github_changelog_generator", "1.13.1"
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -20,15 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.1.0"
   spec.add_dependency "inspec", ">=0.22.0", "<1.0.0"
   spec.add_dependency "test-kitchen", "~> 1.6"
-  spec.add_development_dependency "countloc", "~> 0.4"
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "simplecov", "~> 0.10"
-  # style and complexity libraries are tightly version pinned as newer releases
-  # may introduce new and undesireable style choices which would be immediately
-  # enforced in CI
-  spec.add_development_dependency "chefstyle", "0.4.0"
 end


### PR DESCRIPTION
Ruby 1.9 and 2.0 are EOL and we shouldn't be supporting them anymore.

#98 needs to get merged first for this to make sense