### PR TITLE
Add host and port config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ verifier:
   sudo_command: 'skittles'
 ```
 
+You can also specify the host and port to be used by InSpec when targeting the node. Otherwise, it defaults to the hostname and port used by kitchen for converging.
+
+```yaml
+verifier:
+  name: inspec
+  host: 192.168.56.40
+  port: 22
+```
+
 ### Directory Structure
 
 By default `kitchen-inspec` expects test to be in `test/integration/%suite%` directory structure (we use Chef as provisioner here):

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -169,8 +169,8 @@ module Kitchen
           # pass-in sudo config from kitchen verifier
           "sudo" => config[:sudo],
           "sudo_command" => config[:sudo_command],
-          "host" => kitchen[:hostname],
-          "port" => kitchen[:port],
+          "host" => config[:host] || kitchen[:hostname],
+          "port" => config[:port] || kitchen[:port],
           "user" => kitchen[:username],
           "keepalive" => kitchen[:keepalive],
           "keepalive_interval" => kitchen[:keepalive_interval],
@@ -196,8 +196,8 @@ module Kitchen
         opts = {
           "backend" => "winrm",
           "logger" => logger,
-          "host" => URI(kitchen[:endpoint]).hostname,
-          "port" => URI(kitchen[:endpoint]).port,
+          "host" => config[:host] || URI(kitchen[:endpoint]).hostname,
+          "port" => config[:port] || URI(kitchen[:endpoint]).port,
           "user" => kitchen[:user],
           "password" => kitchen[:password] || kitchen[:pass],
           "connection_retries" => kitchen[:connection_retries],

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -172,6 +172,23 @@ describe Kitchen::Verifier::Inspec do
       verifier.call(port: 123)
     end
 
+    it "constructs a Inspec::Runner using transport config data(host and port)" do
+      config[:host] = "192.168.33.40"
+      config[:port] = 222
+
+      expect(Inspec::Runner).to receive(:new)
+        .with(
+          hash_including(
+            "backend" => "ssh",
+            "host" => "192.168.33.40",
+            "port" => 222
+          )
+        )
+        .and_return(runner)
+
+      verifier.call(port: 123)
+    end
+
     it "constructs an Inspec::Runner with a specified inspec output format" do
       config[:format] = "documentation"
 
@@ -318,6 +335,23 @@ describe Kitchen::Verifier::Inspec do
             "connection_retry_sleep" => "sleepy",
             "max_wait_until_ready" => 42,
             "color" => true
+          )
+        )
+        .and_return(runner)
+
+      verifier.call(hostname: "win.dows", port: 123)
+    end
+
+    it "constructs a Inspec::Runner using transport config data(host and port)" do
+      config[:host] = "192.168.56.40"
+      config[:port] = 22
+
+      expect(Inspec::Runner).to receive(:new)
+        .with(
+          hash_including(
+            "backend" => "winrm",
+            "host" => "192.168.56.40",
+            "port" => 22
           )
         )
         .and_return(runner)


### PR DESCRIPTION
When using kitchen vagrant, inspec is targeting 127.0.0.1 with the forwarded port provided by kitchen:

```
$ kitchen verify
-----> Starting Kitchen (v1.13.2)
-----> Verifying <mysuite-centos6>...
       Use `/Users/apop/git/myapache-cookbook/test/integration/mysuite` for testing

Target:  ssh://root@127.0.0.1:2222
```

This prevents resources like `ssl` from getting a real host they can connect to. This PR adds two config options to be able to specify the host and port to be used by inspec instead on relying on the kitchen ones. Output:

```
$ be kitchen verify
-----> Starting Kitchen (v1.6.0)
-----> Verifying <mysuite-centos6>...
       Use `/Users/apop/git/myapache-cookbook/test/integration/mysuite` for testing

Target:  ssh://root@192.168.33.40:22

  SSL/TLS on
     ✔  192.168.33.40:443 with protocol == "tls1.2" should be enabled
```
