### PR TITLE
Make the info message clearer

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -119,7 +119,7 @@ module Kitchen
         end
 
         base = File.join(base, "inspec") if legacy_mode
-        logger.info("Use `#{base}` for testing")
+        logger.info("Using `#{base}` for testing")
 
         # only return the directory if it exists
         Pathname.new(base).exist? ? [base] : []


### PR DESCRIPTION
This message leads me to believe I have to fix something since it says `Use`. By changing that word to `Using` it makes it clearer that it is purely an informational message as opposed to something I need to fix.