### PR TITLE
Support multiple outputs based on platform/test suite variables (issue 121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ verifier:
   port: 22
 ```
 
+If you want to customize the output file per platform or test suite
+you can use template format for your output variable. Current flags
+supported:
+ * _%{platform}_
+ * _%{suite}_
+
+```yaml
+verifier:
+  name: inspec
+  format: junit
+  output: path/to/results/%{platform}_%{suite}_inspec.xml
+```
+
 ### Directory Structure
 
 By default `kitchen-inspec` expects test to be in `test/integration/%suite%` directory structure (we use Chef as provisioner here):

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -66,7 +66,7 @@ module Kitchen
         logger.debug("Initialize InSpec")
 
         # gather connection options
-        opts = runner_options(instance.transport, state)
+        opts = runner_options(instance.transport, state, instance.platform.name, instance.suite.name)
 
         # add attributes
         opts[:attrs] = config[:attrs]
@@ -159,7 +159,7 @@ module Kitchen
       #
       # @return [Hash] a configuration hash of string-based keys
       # @api private
-      def runner_options(transport, state = {}) # rubocop:disable Metrics/AbcSize
+      def runner_options(transport, state = {}, platform = nil, suite = nil) # rubocop:disable Metrics/AbcSize
         transport_data = transport.diagnose.merge(state)
         if transport.is_a?(Kitchen::Transport::Ssh)
           runner_options_for_ssh(transport_data)
@@ -174,7 +174,7 @@ module Kitchen
           # default color to true to match InSpec behavior
           runner_options["color"] = (config[:color].nil? ? true : config[:color])
           runner_options["format"] = config[:format] unless config[:format].nil?
-          runner_options["output"] = config[:output] unless config[:output].nil?
+          runner_options["output"] = config[:output] % { platform: platform, suite: suite } unless config[:output].nil?
           runner_options["profiles_path"] = config[:profiles_path] unless config[:profiles_path].nil?
         end
       end


### PR DESCRIPTION
Hi,

in order to workaround issue https://github.com/chef/kitchen-inspec/issues/121 we came up with this implementation: support template format for _verifier.output_ parameter. Right now only *platform* and *suite* are supported, but it easy to add more parameters if they are needed. 

Default output is not modified, as well as custom path option. The only behavior updated here is when you define the output as format string (%{}), so given _platform_ or _suite_ flags they will be replace (in that way, you can specify an output value in the general _verifier_ section, but multiple inspec files will be created based on the flags.

Added unit test and README block explaining this feature.

Thanks @AgarFu for your help!