### PR TITLE
Add support for pty config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ verifier:
   sudo_command: 'skittles'
 ```
 
+If you are verifying a host that requires a PTY to run sudo you can set pty to true
+
+```yaml
+verifier:
+  name: inspec
+  sudo: true
+  pty: true
+```
+
 You can also specify the host and port to be used by InSpec when targeting the node. Otherwise, it defaults to the hostname and port used by kitchen for converging.
 
 ```yaml

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -203,6 +203,7 @@ module Kitchen
           "sudo" => config[:sudo],
           "sudo_command" => config[:sudo_command],
           "sudo_options" => config[:sudo_options],
+          "pty" => config[:pty],
           "host" => config[:host] || kitchen[:hostname],
           "port" => config[:port] || kitchen[:port],
           "user" => kitchen[:username],


### PR DESCRIPTION
Some hosts are configured to require a pty when using sudo. This will
result in the following error:

> Sudo failed: Sudo requires a TTY. Please see the README on how to
> configure sudo to allow for non-interactive usage.

It may not always be desirable to remove the `requiretty` flag in the
sudo configuration, so I am suggesting that we add the ability to use
a pty when connecting with SSH for those cases. Since this is already
supported in Train, all we need to do is expose that setting in
`.kitchen.yml`.