### PR TITLE
Don't send keys_only config to InSpec/Train

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -214,7 +214,6 @@ module Kitchen
           "max_wait_until_ready" => kitchen[:max_wait_until_ready],
           "compression" => kitchen[:compression],
           "compression_level" => kitchen[:compression_level],
-          "keys_only" => true,
         }
         opts["key_files"] = kitchen[:keys] unless kitchen[:keys].nil?
         opts["password"] = kitchen[:password] unless kitchen[:password].nil?

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -217,6 +217,18 @@ describe Kitchen::Verifier::Inspec do
       verifier.call(port: 123)
     end
 
+    it "does not send keys_only=true to InSpec (which breaks SSH Agent usage)" do
+      expect(Inspec::Runner).to receive(:new)
+        .with(
+          hash_not_including(
+            "keys_only" => true
+          )
+        )
+        .and_return(runner)
+
+      verifier.call(port: 123)
+    end
+
     it "provide platform and test suite to build output path" do
       allow(Inspec::Runner).to receive(:new).and_return(runner)
 


### PR DESCRIPTION
kitchen-inspec currently sends `keys_only` set to `true` which prevents net-ssh from properly using credentials provided by a user's SSH Agent. Train already does the right thing by checking the Agent for available identities and sets `keys_only` as needed.

Therefore, this change eliminates this config parameter and lets Train do The Right Thing.

Related to chef/train#183