### PR TITLE
Allow extending which transports are supported by kitchen-inspec

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -187,13 +187,8 @@ module Kitchen
       # @api private
       def runner_options(transport, state = {}, platform = nil, suite = nil) # rubocop:disable Metrics/AbcSize
         transport_data = transport.diagnose.merge(state)
-        if transport.is_a?(Kitchen::Transport::Ssh)
-          runner_options_for_ssh(transport_data)
-        elsif transport.is_a?(Kitchen::Transport::Winrm)
-          runner_options_for_winrm(transport_data)
-        # optional transport which is not in core test-kitchen
-        elsif defined?(Kitchen::Transport::Dokken) && transport.is_a?(Kitchen::Transport::Dokken)
-          runner_options_for_docker(transport_data)
+        if respond_to?("runner_options_for_#{transport.name.downcase}")
+          send("runner_options_for_#{transport.name.downcase}", transport_data)
         else
           raise Kitchen::UserError, "Verifier #{name} does not support the #{transport.name} Transport"
         end.tap do |runner_options|
@@ -260,7 +255,7 @@ module Kitchen
       #
       # @return [Hash] a configuration hash of string-based keys
       # @api private
-      def runner_options_for_docker(config_data)
+      def runner_options_for_dokken(config_data)
         kitchen = instance.transport.send(:connection_options, config_data).dup
         #
         # Note: kitchen-dokken uses two containers the

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -187,7 +187,7 @@ module Kitchen
       # @api private
       def runner_options(transport, state = {}, platform = nil, suite = nil) # rubocop:disable Metrics/AbcSize
         transport_data = transport.diagnose.merge(state)
-        if respond_to?("runner_options_for_#{transport.name.downcase}")
+        if respond_to?("runner_options_for_#{transport.name.downcase}", true)
           send("runner_options_for_#{transport.name.downcase}", transport_data)
         else
           raise Kitchen::UserError, "Verifier #{name} does not support the #{transport.name} Transport"


### PR DESCRIPTION
This adds a way to inject support for new transports in to the verifier. Combined with Train's existing plugin registry system, this will allow me to manage transports without direct support in kitchen-inspec.