### PR TITLE
correctly configure HTTPS WinRM

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -240,6 +240,8 @@ module Kitchen
         opts = {
           "backend" => "winrm",
           "logger" => logger,
+          "ssl" => URI(kitchen[:endpoint]).scheme=='https',
+          "self_signed" => kitchen[:no_ssl_peer_verification],
           "host" => config[:host] || URI(kitchen[:endpoint]).hostname,
           "port" => config[:port] || URI(kitchen[:endpoint]).port,
           "user" => kitchen[:user],


### PR DESCRIPTION
This fixes Issue #152, by analyzing the proper parts of the Kitchen Transport connection options and applying them to the runner options for winrm.

Fixes #152 