### PR TITLE
Add the InSpec backend_cache option

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -67,6 +67,7 @@ module Kitchen
 
         # gather connection options
         opts = runner_options(instance.transport, state, instance.platform.name, instance.suite.name)
+        logger.debug "Options #{opts.inspect}"
 
         # add attributes
         opts[:attrs] = config[:attrs]
@@ -198,6 +199,13 @@ module Kitchen
           runner_options["output"] = config[:output] % { platform: platform, suite: suite } unless config[:output].nil?
           runner_options["profiles_path"] = config[:profiles_path] unless config[:profiles_path].nil?
           runner_options[:controls] = config[:controls]
+
+          # check to make sure we have a valid version for caching
+          if config[:backend_cache]
+            backend_cache_msg = "backend_cache requires InSpec version >= 1.47.0"
+            logger.warn backend_cache_msg if Gem::Version.new(::Inspec::VERSION) < Gem::Version.new("1.47.0")
+          end
+          runner_options[:backend_cache] = config[:backend_cache].nil? ? true : config[:backend_cache]
         end
       end
 
@@ -240,7 +248,7 @@ module Kitchen
         opts = {
           "backend" => "winrm",
           "logger" => logger,
-          "ssl" => URI(kitchen[:endpoint]).scheme=='https',
+          "ssl" => URI(kitchen[:endpoint]).scheme == "https",
           "self_signed" => kitchen[:no_ssl_peer_verification],
           "host" => config[:host] || URI(kitchen[:endpoint]).hostname,
           "port" => config[:port] || URI(kitchen[:endpoint]).port,

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -204,8 +204,11 @@ module Kitchen
           if config[:backend_cache]
             backend_cache_msg = "backend_cache requires InSpec version >= 1.47.0"
             logger.warn backend_cache_msg if Gem::Version.new(::Inspec::VERSION) < Gem::Version.new("1.47.0")
+            runner_options[:backend_cache] = config[:backend_cache]
+          else
+            # default to false until we default to true in inspec
+            runner_options[:backend_cache] = false
           end
-          runner_options[:backend_cache] = config[:backend_cache].nil? ? true : config[:backend_cache]
         end
       end
 

--- a/lib/kitchen/verifier/inspec_version.rb
+++ b/lib/kitchen/verifier/inspec_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Verifier
     # Version string for InSpec Kitchen verifier
-    INSPEC_VERSION = "0.20.0"
+    INSPEC_VERSION = "0.21.0"
   end
 end

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -33,7 +33,7 @@ describe Kitchen::Verifier::Inspec do
     {
       kitchen_root: kitchen_root,
       test_base_path: File.join(kitchen_root, "test", "integration"),
-      backend_cache: false,
+      backend_cache: true,
     }
   end
   let(:transport_config)  { {} }
@@ -93,15 +93,15 @@ describe Kitchen::Verifier::Inspec do
       Kitchen::Transport::Ssh.new({})
     end
 
-    it "backend_cache option sets to false" do
-      config = verifier.send(:runner_options, transport)
-      expect(config.to_hash).to include(backend_cache: false)
-    end
-
-    it "backend_cache option defaults to true" do
-      config[:backend_cache] = nil
+    it "backend_cache option sets to true" do
       config = verifier.send(:runner_options, transport)
       expect(config.to_hash).to include(backend_cache: true)
+    end
+
+    it "backend_cache option defaults to false" do
+      config[:backend_cache] = nil
+      config = verifier.send(:runner_options, transport)
+      expect(config.to_hash).to include(backend_cache: false)
     end
 
     it "inspec version warn for backend_cache" do

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -33,6 +33,7 @@ describe Kitchen::Verifier::Inspec do
     {
       kitchen_root: kitchen_root,
       test_base_path: File.join(kitchen_root, "test", "integration"),
+      backend_cache: false,
     }
   end
   let(:transport_config)  { {} }
@@ -88,7 +89,30 @@ describe Kitchen::Verifier::Inspec do
   end
 
   describe "configuration" do
-    # nothing yet, woah!
+    let(:transport) do
+      Kitchen::Transport::Ssh.new({})
+    end
+
+    it "backend_cache option sets to false" do
+      config = verifier.send(:runner_options, transport)
+      expect(config.to_hash).to include(backend_cache: false)
+    end
+
+    it "backend_cache option defaults to true" do
+      config[:backend_cache] = nil
+      config = verifier.send(:runner_options, transport)
+      expect(config.to_hash).to include(backend_cache: true)
+    end
+
+    it "inspec version warn for backend_cache" do
+      config[:backend_cache] = true
+      stub_const("Inspec::VERSION", "1.46.0")
+      expect_any_instance_of(Logger).to receive(:warn).
+        with("backend_cache requires InSpec version >= 1.47.0").
+        and_return("captured")
+      config = verifier.send(:runner_options, transport)
+      expect(config.to_hash).to include(backend_cache: true)
+    end
   end
 
   describe "#finalize_config!" do


### PR DESCRIPTION
Fixes https://github.com/chef/kitchen-inspec/issues/154

This PR introduces the new backend_cache option. This flag will default to true if not defined in your kitchen.yml.

Signed-off-by: Jared Quick <jquick@chef.io>