### PR TITLE
git fetcher: support branch/tag/ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,29 +9,31 @@ services:
   - docker
 bundler_args: "--without integration guard tools"
 before_install:
-  - gem install bundler
+  - gem update --system
   - gem --version
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler
+  - bundle --version
 matrix:
   include:
-  - rvm: 2.1.9
-  - rvm: 2.2.5
-  - rvm: 2.3.1
+  - rvm: 2.3.6
+  - rvm: 2.4.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='default profile contains_inspec'
-  - rvm: 2.3.1
+  - rvm: 2.4.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='backwards'
-  - rvm: 2.3.1
+  - rvm: 2.4.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='duplicates'
-  - rvm: 2.3.1
+  - rvm: 2.4.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='supermarket'
-  - rvm: 2.3.1
+  - rvm: 2.4.3
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='attributes-inline attributes-file'

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -157,7 +157,9 @@ module Kitchen
             # foiled by extra stuff. However, if the only entry is a "name" key, then
             # leave it alone so it can default to resolving to the Supermarket.
             unless test_item.keys == [:name]
-              test_item.delete_if { |k, v| ![:path, :url, :git, :compliance].include?(k) }
+              type_keys = [:path, :url, :git, :compliance]
+              git_keys = [:branch, :tag, :ref]
+              test_item.delete_if { |k, v| !(type_keys + git_keys).include?(k) }
             end
           elsif File.exist?(test_item)
             # if the entry is a path to something on disk, rewrite as a Hash entry with a path key.


### PR DESCRIPTION
When fixing an unrelated issue, the configuration keys necessary to properly fetch a profile via git AND specify a branch/tag/reference was inadvertently broken. This change properly restores that functionality.

Fixes #157