### PR TITLE
Update kitchen inspec to support inspec 2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem "minitest", "~> 5.5"
   gem "rake", "~> 11.0"
   gem "chefstyle", "0.4.0"
-  gem "concurrent-ruby", "~> 0.9"
+  gem "concurrent-ruby", "~> 1.0"
   gem "codeclimate-test-reporter", :require => nil
   gem "rspec"
   gem "simplecov", "~> 0.12"

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1.0"
-  spec.add_dependency "inspec", ">=0.34.0", "<2.0.0"
+  spec.add_dependency "inspec", ">=0.34.0", "<3.0.0"
   spec.add_dependency "test-kitchen", "~> 1.6"
   spec.add_dependency "hashie", "~> 3.4"
 end


### PR DESCRIPTION
This updates the gems for kitchen inspec to support inspec 2.0

Fixes https://github.com/chef/kitchen-inspec/issues/165

Signed-off-by: Jared Quick <jquick@chef.io>