### PR TITLE
Add inspec exit code 101 to the approved list

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -93,7 +93,8 @@ module Kitchen
         end
 
         exit_code = runner.run
-        return if exit_code == 0
+        # 101 is a success as well (exit with no fails but has skipped controls)
+        return if exit_code == 0 || exit_code == 101
         raise ActionFailed, "Inspec Runner returns #{exit_code}"
       end
 


### PR DESCRIPTION
This adds 101 to the list of approved exit codes. This allows kitchen-inspec to exit cleanly if we have a 0 or 101.

Ex: (before and after)
![screen shot 2018-03-05 at 2 02 59 pm](https://user-images.githubusercontent.com/574637/36994282-a136d966-207e-11e8-9330-442ccf1f047c.png)

Errors will continue to exit with errors:
![screen shot 2018-03-05 at 2 08 50 pm](https://user-images.githubusercontent.com/574637/36994337-cadeb126-207e-11e8-9e14-c88afc42c46b.png)

Fixes https://github.com/chef/inspec/issues/2773

Signed-off-by: Jared Quick <jquick@chef.io>