### PR TITLE
Add the 'reporter' configuration option to kitchen-inspec

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -201,6 +201,7 @@ module Kitchen
           runner_options["format"] = config[:format] unless config[:format].nil?
           runner_options["output"] = config[:output] % { platform: platform, suite: suite } unless config[:output].nil?
           runner_options["profiles_path"] = config[:profiles_path] unless config[:profiles_path].nil?
+          runner_options["reporter"] = config[:reporter] unless config[:reporter].nil?
           runner_options[:controls] = config[:controls]
 
           # check to make sure we have a valid version for caching


### PR DESCRIPTION
Signed-off-by: Tim Pringle <tim.pringle@poweshell.amsterdam>

The --format option is being being deprecated and will be removed in inspec 3.0.
This change allows the use of the --reporter parameter in a Kitchen config file.
Usage example:
```
verifier:
  name: inspec
  reporter:
    - progress
    - json:/tmp/json.txt
```
NB: Unlike 'format', 'reporter' is always parsed as a collection. As such it must be written appropriately in your .yml file when there is only one parameter as well.
```
verifier:
  name: inspec
  reporter:
    - progress
```
