### PR TITLE
CHEF-27138 - Remove SLA text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Kitchen::InSpec - A Test Kitchen Verifier for InSpec
 
-- **Project State: Active**
-- **Issues Response SLA: 3 business days**
-- **Pull Request Response SLA: 3 business days**
-
-For more information on project states and SLAs, see [this documentation](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md).
-
 [![Build Status Master](https://travis-ci.org/inspec/kitchen-inspec.svg?branch=master)](https://travis-ci.org/inspec/kitchen-inspec) [![Gem Version](https://badge.fury.io/rb/kitchen-inspec.svg)](https://badge.fury.io/rb/kitchen-inspec)
 
 This is the kitchen driver for [InSpec](https://github.com/chef/inspec). To see the project in action, we have the following test-kitchen examples available:


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 

As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).