### PR TITLE
CHEF-27694 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Author:: Fletcher Nichol (<fnichol@chef.io>)
 
-Copyright (C) 2015, Chef Software Inc.
+Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -366,3 +366,8 @@ Bug reports and pull requests are welcome on GitHub at <https://github.com/inspe
 Apache 2.0 (see [LICENSE])
 
 [license]: https://github.com/inspec/kitchen-inspec/blob/master/LICENSE
+
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -2,7 +2,7 @@
 # Author:: Fletcher Nichol (<fnichol@chef.io>)
 # Author:: Christoph Hartmann (<chartmann@chef.io>)
 #
-# Copyright (C) 2015-2019, Chef Software Inc.
+# Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/verifier/inspec_version.rb
+++ b/lib/kitchen/verifier/inspec_version.rb
@@ -2,7 +2,7 @@
 # Author:: Fletcher Nichol (<fnichol@chef.io>)
 # Author:: Christoph Hartmann (<chartmann@chef.io>)
 #
-# Copyright (C) 2015-2019, Chef Software Inc.
+# Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -2,7 +2,7 @@
 # Author:: Fletcher Nichol (<fnichol@chef.io>)
 # Author:: Christoph Hartmann (<chartmann@chef.io>)
 #
-# Copyright (C) 2015, Chef Software Inc.
+# Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Fletcher Nichol (<fnichol@chef.io>)
 #
-# Copyright (C) 2015-2018, Chef Software Inc.
+# Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/profile/controls/example.rb
+++ b/test/integration/profile/controls/example.rb
@@ -1,4 +1,4 @@
-# copyright: 2015, Chef Software, Inc.
+# copyright: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # license: All rights reserved
 
 title "/tmp profile"

--- a/test/integration/profile/controls/gordon.rb
+++ b/test/integration/profile/controls/gordon.rb
@@ -1,4 +1,4 @@
-# copyright: 2015, Chef Software, Inc.
+# copyright: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # license: All rights reserved
 
 title "Gordon Config Checks"

--- a/test/integration/profile/inspec.yml
+++ b/test/integration/profile/inspec.yml
@@ -1,7 +1,7 @@
 name: profile
 title: InSpec Example Profile
 maintainer: Chef Software, Inc.
-copyright: Chef Software, Inc.
+copyright: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 copyright_email: support@chef.io
 license: Apache 2 license
 summary: Demonstrates the use of InSpec Compliance Profile


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2015-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `LICENSE:3` - Copyright in LICENSE file (move to COPYRIGHT)
- `README.md:1` - adjust-readme
- `test/integration/profile/inspec.yml:5` - Unmatched copyright format (review needed)

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
